### PR TITLE
`PreRequestHook` 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,9 +2,12 @@ import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { AlsModule } from './common/als/als.module';
 import { CorrelationMiddleware } from './common/middleware/correlation.middleware';
 import { DeviceModule } from './device/device.module';
+import { APP_GUARD } from '@nestjs/core';
+import { DeviceContextGuard } from './common/guards/device-context.guard';
 
 @Module({
   imports: [AlsModule, DeviceModule],
+  providers: [{ provide: APP_GUARD, useClass: DeviceContextGuard }],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer): void {

--- a/src/common/guards/device-context.guard.ts
+++ b/src/common/guards/device-context.guard.ts
@@ -1,0 +1,15 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { AlsService } from '../als/als.service';
+
+@Injectable()
+export class DeviceContextGuard implements CanActivate {
+  constructor(private readonly alsService: AlsService) {}
+
+  canActivate(_context: ExecutionContext): boolean {
+    const store = this.alsService.getStore();
+    console.log(
+      `[DeviceContextGuard] correlationId=${store?.correlationId} deviceId=${store?.deviceId}`,
+    );
+    return true;
+  }
+}

--- a/src/common/hooks/prerequest.hook.ts
+++ b/src/common/hooks/prerequest.hook.ts
@@ -1,0 +1,25 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { v4 as uuidv4 } from 'uuid';
+import { AlsService } from '../als/als.service';
+import { AlsStore } from '../als/als.types';
+
+export type PreRequestHook = (
+  context: ExecutionContext,
+  next: () => Observable<unknown>,
+) => Observable<unknown> | Promise<Observable<unknown>>;
+
+export function makePreRequestHook(alsService: AlsService): PreRequestHook {
+  return (context: ExecutionContext, next: () => Observable<unknown>) => {
+    const data = context.switchToRpc().getData<Record<string, unknown>>();
+    const store: AlsStore = {
+      correlationId: uuidv4(),
+      deviceId: data?.deviceId as string | undefined,
+      commandId: data?.commandId as string | undefined,
+      transport: 'mqtt',
+    };
+    return new Observable((subscriber) => {
+      alsService.run(store, () => next().subscribe(subscriber));
+    });
+  };
+}


### PR DESCRIPTION
### 변경 이유
MQTT 메시지 수신 시 Guards / Interceptors가 실행되기 전에 ALS store가 초기화되어야 합니다.
NestJS 12에서 공식 지원 예정인 `useGlobalPreRequestHooks`를 `serverInstance.setOnProcessingStartHook`으로 폴리필합니다.

### 주요 변경
- `makePreRequestHook(alsService)`: `PreRequestHook` 팩토리 함수
- `DeviceContextGuard`: ALS store에서 `correlationId` 읽어 로그 출력 (Guards에서도 컨텍스트가 살아있음을 증명)
- `APP_GUARD`로 전역 등록
- `main.ts`: `registerPreRequestHook`으로 훅 연결

### 핵심 패턴
```
// als.run 내부에서 next()를 호출해야 guard 포함 전체 파이프라인이 ALS context 안에서 실행됨
return new Observable(subscriber => {
  alsService.run(store, () => next().subscribe(subscriber));
});
```

### 기술적 선택 및 트레이드오프
- **폴리필 방식**: `serverInstance`를 직접 캐스팅 → NestJS 내부 구현에 의존. NestJS 12 업그레이드 시 `useGlobalPreRequestHooks`로 교체 예정
- **`next()` 위치**: `als.run` 밖에서 호출 시 Observable 구독 시점에 context가 소실됨 → 반드시 `als.run` 콜백 내부에서 `next()` 호출