### PR TITLE
핸들러별 QoS 분리된 MQTT 메시지 핸들러 추가 (telemetry qos:0, ack qos:1)

### DIFF
--- a/src/ack/ack.handler.ts
+++ b/src/ack/ack.handler.ts
@@ -1,0 +1,22 @@
+import { Controller } from '@nestjs/common';
+import { MessagePattern, Payload } from '@nestjs/microservices';
+import { AlsService } from '../common/als/als.service';
+
+interface AckPayload {
+  commandId: string;
+  status: string;
+  deviceId: string;
+}
+
+@Controller()
+export class AckHandler {
+  constructor(private readonly alsService: AlsService) {}
+
+  @MessagePattern('devices/+/acks', { extras: { qos: 1 } })
+  handle(@Payload() data: AckPayload): void {
+    const store = this.alsService.getStore();
+    console.log(
+      `[ack|qos1] corr=${store?.correlationId} cmd=${data.commandId} status=${data.status}`,
+    );
+  }
+}

--- a/src/ack/ack.module.ts
+++ b/src/ack/ack.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { AckHandler } from './ack.handler';
+
+@Module({
+  controllers: [AckHandler],
+})
+export class AckModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,9 +4,11 @@ import { CorrelationMiddleware } from './common/middleware/correlation.middlewar
 import { DeviceModule } from './device/device.module';
 import { APP_GUARD } from '@nestjs/core';
 import { DeviceContextGuard } from './common/guards/device-context.guard';
+import { TelemetryModule } from './telemetry/telemetry.module';
+import { AckModule } from './ack/ack.module';
 
 @Module({
-  imports: [AlsModule, DeviceModule],
+  imports: [AlsModule, DeviceModule, TelemetryModule, AckModule],
   providers: [{ provide: APP_GUARD, useClass: DeviceContextGuard }],
 })
 export class AppModule implements NestModule {

--- a/src/telemetry/telemetry.handler.ts
+++ b/src/telemetry/telemetry.handler.ts
@@ -1,0 +1,24 @@
+import { Controller, UseGuards } from '@nestjs/common';
+import { MessagePattern, Payload } from '@nestjs/microservices';
+import { AlsService } from '../common/als/als.service';
+import { DeviceContextGuard } from '../common/guards/device-context.guard';
+
+interface TelemetryPayload {
+  deviceId: string;
+  battery: number;
+  ts: number;
+}
+
+@Controller()
+export class TelemetryHandler {
+  constructor(private readonly alsService: AlsService) {}
+
+  @UseGuards(DeviceContextGuard)
+  @MessagePattern('devices/+/telemetry', { extras: { qos: 0 } })
+  handle(@Payload() data: TelemetryPayload): void {
+    const store = this.alsService.getStore();
+    console.log(
+      `[telemetry|qos0] corr=${store?.correlationId} dev=${data.deviceId} bat=${data.battery}`,
+    );
+  }
+}

--- a/src/telemetry/telemetry.module.ts
+++ b/src/telemetry/telemetry.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { TelemetryHandler } from './telemetry.handler';
+
+@Module({
+  controllers: [TelemetryHandler],
+})
+export class TelemetryModule {}


### PR DESCRIPTION
### 변경 이유
MQTT에서는 메시지 유형에 따라 적절한 QoS 레벨이 다릅니다.
기존 NestJS는 전역 QoS만 지원했으나 PR #16286 기여로 핸들러별 QoS 지정이 가능해졌습니다.

### 주요 변경
- `TelemetryHandler`: `devices/+/telemetry` 구독, `extras: { qos: 0 }` (빠른 센서 데이터)
- `AckHandler`: `devices/+/acks` 구독, `extras: { qos: 1 }` (최소 1회 전달 보장)

### 기술적 선택 및 트레이드오프
| QoS | 사용처 | 이유 |
|-----|--------|------|
| 0 | telemetry | 배터리·온도 등 빈번한 데이터, 유실 허용 |
| 1 | ack | 명령 수신 확인은 최소 1회 보장 필요 |
| 2 (publish) | stop command | HTTP→MQTT 발행 시 중복 방지 최우선 |

- **`extras.qos: 0` falsy 이슈**: `extras?.qos !== undefined` 조건으로 0을 유효한 값으로 처리 (기여 시 직접 발견한 버그)