### PR TITLE
 디바이스 정지 API 추가

### DIFF
--- a/src/device/device.controller.ts
+++ b/src/device/device.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Param, Post } from '@nestjs/common';
+import { AlsService } from '../common/als/als.service';
+import { DeviceService } from './device.service';
+
+@Controller('devices')
+export class DeviceController {
+  constructor(
+    private readonly deviceService: DeviceService,
+    private readonly alsService: AlsService,
+  ) {}
+
+  @Post(':deviceId/stop')
+  async stop(
+    @Param('deviceId') deviceId: string,
+  ): Promise<Record<string, unknown>> {
+    const commandId = await this.deviceService.publishStop(deviceId);
+    const store = this.alsService.getStore();
+    return { commandId, correlationId: store?.correlationId, status: 'sent' };
+  }
+}

--- a/src/device/device.module.ts
+++ b/src/device/device.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { DeviceController } from './device.controller';
+import { DeviceService } from './device.service';
+
+@Module({
+  controllers: [DeviceController],
+  providers: [DeviceService],
+})
+export class DeviceModule {}

--- a/src/device/device.service.ts
+++ b/src/device/device.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import * as mqtt from 'mqtt';
+import { v4 as uuidv4 } from 'uuid';
+
+@Injectable()
+export class DeviceService implements OnModuleInit, OnModuleDestroy {
+  private client!: mqtt.MqttClient;
+
+  onModuleInit(): void {
+    this.client = mqtt.connect(process.env.MQTT_URL ?? 'mqtt://localhost:1883');
+  }
+
+  async publishStop(deviceId: string): Promise<string> {
+    const commandId = uuidv4();
+    await this.client.publishAsync(
+      `devices/${deviceId}/commands/stop`,
+      JSON.stringify({
+        commandId,
+        deviceId,
+        ts: Date.now(),
+        type: 'stop_motor',
+      }),
+      { qos: 2 },
+    );
+    return commandId;
+  }
+
+  onModuleDestroy(): void {
+    this.client.end();
+  }
+}


### PR DESCRIPTION
### 변경 이유
HTTP 요청으로 디바이스에 정지 명령을 내릴 때, 명령 중복 전달을 막기 위해 QoS 2 (exactly-once)로 발행해야 합니다.

### 주요 변경
- `POST /devices/:deviceId/stop` 엔드포인트
- `DeviceService`: raw `mqtt` 클라이언트로 `qos: 2` 발행
- 응답: `{ commandId, correlationId, status: 'sent' }`

### 기술적 선택 및 트레이드오프
- **raw mqtt 클라이언트 사용 이유**: NestJS `ClientProxy.emit()`은 per-message QoS 미지원 → 직접 `mqtt.connect()` 사용
- **트레이드오프**: 커넥션 관리를 직접 해야 함 (`OnModuleInit`/`OnModuleDestroy`로 생명주기 연결)