### PR TITLE
HTTP + MQTT 하이브리드 앱 부트스트랩 및 PreRequestHook 등록

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,99 @@
 import { NestFactory } from '@nestjs/core';
+import {
+  MicroserviceOptions,
+  MqttContext,
+  Transport,
+} from '@nestjs/microservices';
+import { ExecutionContextHost } from '@nestjs/core/helpers/execution-context-host';
+import { Observable } from 'rxjs';
 import { AppModule } from './app.module';
+import { AlsService } from './common/als/als.service';
+import {
+  makePreRequestHook,
+  PreRequestHook,
+} from './common/hooks/prerequest.hook';
 
-async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  await app.listen(process.env.PORT ?? 3000);
+type ProcessingStartHook = (
+  transportId: unknown,
+  context: unknown,
+  done: () => void | Promise<void>,
+) => void;
+
+interface ServerWithHook {
+  setOnProcessingStartHook(hook: ProcessingStartHook): void;
 }
-bootstrap();
+
+async function bootstrap(): Promise<void> {
+  const app = await NestFactory.create(AppModule);
+  const alsService = app.get(AlsService);
+
+  const microservice = app.connectMicroservice<MicroserviceOptions>({
+    transport: Transport.MQTT,
+    options: { url: process.env.MQTT_URL ?? 'mqtt://localhost:1883' },
+  });
+
+  registerPreRequestHook(microservice, makePreRequestHook(alsService));
+
+  await app.startAllMicroservices();
+  await app.listen(process.env.PORT ?? 3000);
+  console.log(`HTTP server listening on port ${process.env.PORT ?? 3000}`);
+}
+
+function registerPreRequestHook(
+  microservice: { serverInstance?: unknown },
+  hook: PreRequestHook,
+): void {
+  const server = (microservice as { serverInstance: ServerWithHook })
+    .serverInstance;
+
+  if (!server || typeof server.setOnProcessingStartHook !== 'function') {
+    console.warn(
+      '[PreRequestHook] setOnProcessingStartHook not available on server instance',
+    );
+    return;
+  }
+
+  server.setOnProcessingStartHook(
+    (
+      _transportId: unknown,
+      ctx: unknown,
+      done: () => void | Promise<void>,
+    ): void => {
+      const mqttCtx = ctx as MqttContext;
+      let parsedData: Record<string, unknown> = {};
+      try {
+        const packet = mqttCtx.getPacket() as { payload?: Buffer | string };
+        if (packet?.payload) {
+          parsedData = JSON.parse(packet.payload.toString()) as Record<
+            string,
+            unknown
+          >;
+        }
+      } catch {
+        // non-JSON payload — leave parsedData empty
+      }
+
+      const execCtx = new ExecutionContextHost([parsedData, mqttCtx]);
+      execCtx.setType('rpc');
+
+      const next = (): Observable<unknown> =>
+        new Observable<unknown>((sub) => {
+          Promise.resolve(done())
+            .then(() => {
+              sub.next(undefined);
+              sub.complete();
+            })
+            .catch((err) => sub.error(err as Error));
+        });
+
+      const result = hook(execCtx, next);
+      void Promise.resolve(result).then((obs$) =>
+        obs$.subscribe({
+          error: (err: unknown) => console.error('[PreRequestHook error]', err),
+        }),
+      );
+    },
+  );
+}
+
+void bootstrap();


### PR DESCRIPTION
### 변경 이유
NestJS Hybrid App으로 HTTP와 MQTT를 동시에 구동하고, MQTT 파이프라인에 PreRequestHook을 연결합니다.

### 주요 변경
- `NestFactory.create(AppModule)` + `connectMicroservice(MQTT)`
- `registerPreRequestHook`으로 `serverInstance.setOnProcessingStartHook` 연결
- MQTT 패킷 payload 파싱 → `ExecutionContext` 구성 → hook 실행

### 기술적 선택
- **`connectMicroservice` 반환값에서 `serverInstance` 접근**: 타입 캐스팅 필요 (`{ serverInstance: ServerWithHook }`)
- **Observable 기반 done() 래핑**: `setOnProcessingStartHook`의 `done` 콜백을 Observable로 변환해 PreRequestHook 시그니처와 호환