### PR TITLE
feat: 멱등성 처리가 포함된 디바이스 시뮬레이터 및 테스트 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,170 @@
+# qos-control-hub
+
+NestJS 11 Hybrid App(HTTP + MQTT)으로 두 가지 NestJS 기여 기능을 실제 도메인에 적용한 데모 프로젝트.
+
+1. **`@MessagePattern` extras.qos** — 핸들러별 MQTT 구독 QoS 분리
+2. **PreRequest Hook** — Guards 실행 전 `AsyncLocalStorage` 컨텍스트 전파
+
+---
+
+## 핵심 개념
+
+### 1. extras.qos
+
+`@MessagePattern`의 두 번째 인수 `extras`에 `qos`를 지정하면 해당 핸들러가 그 QoS로 구독한다.
+
+```typescript
+// qos:0 — telemetry (유실 허용)
+@MessagePattern('devices/+/telemetry', { extras: { qos: 0 } })
+
+// qos:1 — ack (최소 1회 보장)
+@MessagePattern('devices/+/acks', { extras: { qos: 1 } })
+```
+
+NestJS `ServerMqtt`의 `bindEvents`가 `handler.extras.qos`를 읽어 `mqttClient.subscribe` 옵션에 주입한다.
+
+---
+
+### 2. PreRequest Hook (ALS 전파)
+
+Guards보다 먼저 실행되는 훅으로 `AsyncLocalStorage` 컨텍스트를 전파한다. 현재 NestJS 11.1.x 미구현이므로 `Server.setOnProcessingStartHook`으로 폴리필한다.
+
+```
+MQTT 메시지 수신
+  └─ setOnProcessingStartHook 어댑터
+       └─ als.run(store, () => next().subscribe(...))
+            ├─ Guards 실행         ← getStore() 유효
+            ├─ Interceptors 실행   ← getStore() 유효
+            └─ Handler 실행        ← getStore() 유효
+```
+
+`als.run` 내부에서 `next()`를 호출하기 때문에, 이후 모든 비동기 체인에서 `AsyncLocalStorage.getStore()`가 동일한 store를 반환한다.
+
+---
+
+## 프로젝트 구조
+
+```
+qos-control-hub/
+├── docker-compose.yml
+├── mosquitto/config/mosquitto.conf
+├── scripts/
+│   └── simulator.ts              # 독립 디바이스 시뮬레이터
+└── src/
+    ├── main.ts                   # Hybrid app bootstrap
+    ├── app.module.ts
+    ├── common/
+    │   ├── als/                  # AsyncLocalStorage 전역 모듈
+    │   │   ├── als.module.ts
+    │   │   ├── als.service.ts
+    │   │   └── als.types.ts
+    │   ├── hooks/
+    │   │   └── prerequest.hook.ts  # makePreRequestHook 팩토리
+    │   ├── guards/
+    │   │   └── device-context.guard.ts  # ALS store 로그 (APP_GUARD)
+    │   └── middleware/
+    │       └── correlation.middleware.ts  # HTTP ALS 초기화
+    ├── telemetry/                # @MessagePattern qos:0
+    ├── ack/                      # @MessagePattern qos:1
+    └── device/                   # POST /devices/:id/stop (raw mqtt qos:2)
+```
+
+---
+
+## 실행
+
+### 사전 조건
+
+- Node.js 20+
+- Docker
+
+### 1. 의존성 설치
+
+```bash
+npm install
+```
+
+### 2. 브로커 실행
+
+```bash
+docker-compose up -d
+```
+
+### 3. 앱 실행
+
+```bash
+npm run dev
+```
+
+HTTP `:3000` + MQTT `:1883` 동시 구동.
+
+### 4. 시뮬레이터 실행 (별도 터미널)
+
+```bash
+npm run sim
+
+# chaos 모드: 30초마다 강제 재연결
+npm run sim -- --chaos
+```
+
+---
+
+## 동작 확인
+
+**stop command 발행:**
+
+```bash
+curl -X POST localhost:3000/devices/dev-001/stop
+```
+
+```json
+{
+  "commandId": "550e8400-...",
+  "correlationId": "f47ac10b-...",
+  "status": "sent"
+}
+```
+
+**시뮬레이터 로그 (최초 수신):**
+
+```
+[simulator] command 550e8400-...: applied
+[simulator] ack published (qos:1) for 550e8400-...
+```
+
+**동일 curl 재호출 시 (멱등성):**
+
+```
+[simulator] command 550e8400-...: ignored_duplicate
+```
+
+**서버 로그 — telemetry, ack, guard 모두 동일 correlationId 출력:**
+
+```
+[DeviceContextGuard] correlationId=f47ac10b-... deviceId=dev-001
+[telemetry|qos0] corr=f47ac10b-... dev=dev-001 bat=42
+[ack|qos1] corr=f47ac10b-... cmd=550e8400-... status=ok
+```
+
+---
+
+## 테스트
+
+```bash
+npm test
+```
+
+| 파일 | 검증 내용 |
+|------|-----------|
+| `prerequest.hook.spec.ts` | `next()` 내부에서 ALS `getStore()`가 유효한 store 반환 (correlationId, deviceId, transport) |
+| `idempotency.spec.ts` | `processCommand` 멱등성 — 신규: `applied`, 중복: `ignored_duplicate` |
+
+---
+
+## MQTT QoS 정책
+
+| 토픽 | 방향 | QoS | 이유 |
+|------|------|-----|------|
+| `devices/+/telemetry` | Device → Server | 0 | 유실 허용, 최신값만 의미 있음 |
+| `devices/+/acks` | Device → Server | 1 | 명령 처리 결과 최소 1회 보장 |
+| `devices/+/commands/stop` | Server → Device | 2 | 정확히 1회 전달 필수 |

--- a/scripts/simulator.ts
+++ b/scripts/simulator.ts
@@ -1,0 +1,99 @@
+import * as mqtt from 'mqtt';
+
+const DEVICE_ID = process.env.DEVICE_ID ?? 'dev-001';
+const BROKER_URL = process.env.MQTT_URL ?? 'mqtt://localhost:1883';
+const CHAOS_MODE = process.argv.includes('--chaos');
+
+export function processCommand(
+  commandId: string,
+  processed: Set<string>,
+): 'applied' | 'ignored_duplicate' {
+  if (processed.has(commandId)) {
+    return 'ignored_duplicate';
+  }
+  processed.add(commandId);
+  return 'applied';
+}
+
+function createClient(url: string): mqtt.MqttClient {
+  return mqtt.connect(url);
+}
+
+function startSimulator(): void {
+  const processedCommandIds = new Set<string>();
+  let client = createClient(BROKER_URL);
+
+  client.on('connect', () => {
+    console.log(`[simulator] connected to ${BROKER_URL} as ${DEVICE_ID}`);
+
+    client.subscribe(
+      `devices/${DEVICE_ID}/commands/stop`,
+      { qos: 2 },
+      (err) => {
+        if (err) console.error('[simulator] subscribe error', err);
+        else console.log(`[simulator] subscribed to commands/stop (qos:2)`);
+      },
+    );
+
+    const telemetryInterval = setInterval(() => {
+      const payload = JSON.stringify({
+        deviceId: DEVICE_ID,
+        battery: Math.floor(Math.random() * 100),
+        ts: Date.now(),
+      });
+      client.publish(`devices/${DEVICE_ID}/telemetry`, payload, { qos: 0 });
+      console.log(`[simulator] telemetry published (qos:0)`);
+    }, 1000);
+
+    if (CHAOS_MODE) {
+      setInterval(() => {
+        console.log('[simulator] chaos: reconnecting...');
+        clearInterval(telemetryInterval);
+        client.end(false, {}, () => {
+          client = createClient(BROKER_URL);
+          startSimulator();
+        });
+      }, 30_000);
+    }
+  });
+
+  client.on('message', (topic, buffer) => {
+    if (!topic.endsWith('/commands/stop')) return;
+
+    let payload: { commandId?: string; type?: string };
+    try {
+      payload = JSON.parse(buffer.toString()) as {
+        commandId?: string;
+        type?: string;
+      };
+    } catch {
+      console.error('[simulator] invalid JSON command');
+      return;
+    }
+
+    const { commandId } = payload;
+    if (!commandId) return;
+
+    const result = processCommand(commandId, processedCommandIds);
+    console.log(`[simulator] command ${commandId}: ${result}`);
+
+    if (result === 'applied') {
+      const ackPayload = JSON.stringify({
+        commandId,
+        deviceId: DEVICE_ID,
+        status: 'ok',
+        ts: Date.now(),
+      });
+      client.publish(`devices/${DEVICE_ID}/acks`, ackPayload, { qos: 1 });
+      console.log(`[simulator] ack published (qos:1) for ${commandId}`);
+    }
+  });
+
+  client.on('error', (err) => {
+    console.error('[simulator] error', err);
+  });
+}
+
+if (require.main === module) {
+  startSimulator();
+}

--- a/src/common/hooks/prerequest.hook.spec.ts
+++ b/src/common/hooks/prerequest.hook.spec.ts
@@ -1,0 +1,46 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { firstValueFrom, of } from 'rxjs';
+import { AlsModule } from '../als/als.module';
+import { AlsService } from '../als/als.service';
+import { AlsStore } from '../als/als.types';
+import { makePreRequestHook } from './prerequest.hook';
+
+describe('makePreRequestHook', () => {
+  let alsService: AlsService;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AlsModule],
+    }).compile();
+
+    alsService = moduleRef.get(AlsService);
+  });
+
+  it('next() 내부에서 als.getStore()가 유효한 store를 반환한다', async () => {
+    const hook = makePreRequestHook(alsService);
+
+    const mockData = { deviceId: 'dev-001', battery: 80, ts: Date.now() };
+    const mockContext = {
+      switchToRpc: () => ({
+        getData: () => mockData,
+        getContext: () => ({}),
+      }),
+    } as unknown as ExecutionContext;
+
+    let capturedStore: AlsStore | undefined;
+
+    const next = () => {
+      capturedStore = alsService.getStore();
+      return of<unknown>(undefined);
+    };
+
+    const obs$ = await Promise.resolve(hook(mockContext, next));
+    await firstValueFrom(obs$);
+
+    expect(capturedStore).toBeDefined();
+    expect(capturedStore!.correlationId).toBeTruthy();
+    expect(capturedStore!.deviceId).toBe('dev-001');
+    expect(capturedStore!.transport).toBe('mqtt');
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,7 @@ async function bootstrap(): Promise<void> {
 }
 
 function registerPreRequestHook(
-  microservice: { serverInstance?: unknown },
+  microservice: unknown,
   hook: PreRequestHook,
 ): void {
   const server = (microservice as { serverInstance: ServerWithHook })


### PR DESCRIPTION
### 변경 이유
실제 디바이스 동작을 시뮬레이션해 전체 플로우(telemetry → stop command → ack)를 E2E로 검증합니다.
멱등성 처리로 QoS 1/2에서 발생하는 중복 명령을 안전하게 처리합니다.

### 주요 변경
- `scripts/simulator.ts`: 1초마다 telemetry qos:0 발행, stop command qos:2 구독, ack qos:1 발행
- `processCommand(commandId, processedIds)`: Set 기반 멱등성 처리 (export → 테스트 가능)
- `require.main === module` 가드: import 시 MQTT 연결 방지
- `src/scripts/idempotency.spec.ts`: 중복 commandId → `ignored_duplicate`, 신규 → `applied`
- `src/common/hooks/prerequest.hook.spec.ts`: ALS store가 `next()` 내부(guard 위치)에서 유효한지 검증

### 기술적 선택
- **멱등성을 Set으로 구현**: 프로세스 재시작 시 초기화됨 — 프로덕션에서는 Redis 등 외부 저장소 필요 (의도적 단순화)
- **`processCommand` 분리**: 순수 함수로 추출해 MQTT 연결 없이 유닛 테스트 가능